### PR TITLE
Fix OpenMDAO install in GitHub Actions build

### DIFF
--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -25,6 +25,7 @@ jobs:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Set versions to test here ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         PYTHON_VERSION_OLDEST: ['3.8']
         PYTHON_VERSION_LATEST: ['3.11']
+        PIP_VERSION_OLDEST: ['23.0.1']  # pip>=23.1 cannot build the oldest OpenMDAO
         NUMPY_VERSION_OLDEST: ['1.20']  # latest is most recent on PyPI
         SCIPY_VERSION_OLDEST: ['1.6.0']  # latest is most recent on PyPI
         OPENMDAO_VERSION_OLDEST: ['3.10']  # latest is most recent on PyPI
@@ -53,6 +54,7 @@ jobs:
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
+        pip install pip==${{ matrix.PIP_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -35,7 +35,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.PYTHON_VERSION_OLDEST }}
       if: ${{ matrix.dep-versions == 'oldest' }}
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -56,7 +56,7 @@ jobs:
       run: |
         conda config --set always_yes yes
         which python
-        python -m pip install setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
+        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -26,6 +26,7 @@ jobs:
         PYTHON_VERSION_OLDEST: ['3.8']
         PYTHON_VERSION_LATEST: ['3.11']
         PIP_VERSION_OLDEST: ['23.0.1']  # pip>=23.1 cannot build the oldest OpenMDAO
+        SETUPTOOLS_VERSION_OLDEST: ['66.0.0']  # setuptools >= 67.0.0 can't build the oldest OpenMDAO
         NUMPY_VERSION_OLDEST: ['1.20']  # latest is most recent on PyPI
         SCIPY_VERSION_OLDEST: ['1.6.0']  # latest is most recent on PyPI
         OPENMDAO_VERSION_OLDEST: ['3.10']  # latest is most recent on PyPI
@@ -55,7 +56,7 @@ jobs:
       run: |
         conda config --set always_yes yes
         which python
-        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} --upgrade wheel
+        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -25,8 +25,7 @@ jobs:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Set versions to test here ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         PYTHON_VERSION_OLDEST: ['3.8']
         PYTHON_VERSION_LATEST: ['3.11']
-        PIP_VERSION_OLDEST: ['23.0.1']  # pip>=23.1 cannot build the oldest OpenMDAO
-        SETUPTOOLS_VERSION_OLDEST: ['66.0.0']  # setuptools >= 67.0.0 can't build the oldest OpenMDAO
+        WHEEL_VERSION_OLDEST: ['0.38.4'] # latest wheel cannot build the oldest OpenMDAO (3.17 or older)
         NUMPY_VERSION_OLDEST: ['1.20']  # latest is most recent on PyPI
         SCIPY_VERSION_OLDEST: ['1.6.0']  # latest is most recent on PyPI
         OPENMDAO_VERSION_OLDEST: ['3.10']  # latest is most recent on PyPI
@@ -55,7 +54,7 @@ jobs:
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
-        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
+        python -m pip install wheel==${{ matrix.WHEEL_VERSION_OLDEST }}
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -55,7 +55,6 @@ jobs:
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
-        which python
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -56,7 +56,7 @@ jobs:
       run: |
         conda config --set always_yes yes
         which python
-        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
+        python -m pip install setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -54,7 +54,8 @@ jobs:
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
-        pip install pip==${{ matrix.PIP_VERSION_OLDEST }} --upgrade wheel
+        which python
+        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -25,7 +25,8 @@ jobs:
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Set versions to test here ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         PYTHON_VERSION_OLDEST: ['3.8']
         PYTHON_VERSION_LATEST: ['3.11']
-        WHEEL_VERSION_OLDEST: ['0.38.4'] # latest wheel cannot build the oldest OpenMDAO (3.17 or older)
+        PIP_VERSION_OLDEST: ['23.0.1']  # pip>=23.1 cannot build the oldest OpenMDAO
+        SETUPTOOLS_VERSION_OLDEST: ['66.0.0']  # setuptools >= 67.0.0 can't build the oldest OpenMDAO
         NUMPY_VERSION_OLDEST: ['1.20']  # latest is most recent on PyPI
         SCIPY_VERSION_OLDEST: ['1.6.0']  # latest is most recent on PyPI
         OPENMDAO_VERSION_OLDEST: ['3.10']  # latest is most recent on PyPI
@@ -54,7 +55,7 @@ jobs:
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
-        python -m pip install wheel==${{ matrix.WHEEL_VERSION_OLDEST }}
+        python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} openmdao==${{ matrix.OPENMDAO_VERSION_OLDEST }}
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}


### PR DESCRIPTION
## Purpose
The OpenConcept biweekly build fails because OpenMDAO is no longer installing correctly. The error, which this PR fixes, is:
```
Collecting openmdao==3.10
  Downloading openmdao-3.10.0.tar.gz (5.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5.1/5.1 MB [17](https://github.com/mdolab/openconcept/actions/runs/5225381507/jobs/9619604847#step:5:18).4 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in openmdao setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Maintenance update

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
