### PR TITLE
Fix the failed GHA build

### DIFF
--- a/openconcept/aerodynamics/openaerostruct/aerostructural.py
+++ b/openconcept/aerodynamics/openaerostruct/aerostructural.py
@@ -686,7 +686,7 @@ def compute_aerodynamic_data(point):
     compute_W_wing = point[4]
 
     # Set up OpenAeroStruct problem
-    p = om.Problem()
+    p = om.Problem(reports=False)
     p.model.add_subsystem(
         "aero_analysis",
         Aerostruct(

--- a/openconcept/aerodynamics/openaerostruct/drag_polar.py
+++ b/openconcept/aerodynamics/openaerostruct/drag_polar.py
@@ -642,7 +642,7 @@ def compute_aerodynamic_data(point):
     inputs = point[3]
 
     # Set up OpenAeroStruct problem
-    p = om.Problem()
+    p = om.Problem(reports=False)
     p.model.add_subsystem(
         "aero_analysis",
         VLM(


### PR DESCRIPTION
## Purpose
The recent GitHub Actions build failed, I believe because of something to do with the OpenAeroStruct online surrogate model component. My hunch is that, because the training data is generated in parallel with separate OpenMDAO Problems, the parallel problems are overwriting each other's reports. I turned off reports for these problems to hopefully fix it.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
