### PR TITLE
Remove IndepVarComp from heat exchanger model so users can connect things to the DV values

### DIFF
--- a/openconcept/thermal/heat_exchanger.py
+++ b/openconcept/thermal/heat_exchanger.py
@@ -1,5 +1,5 @@
 import numpy as np
-from openmdao.api import ExplicitComponent, IndepVarComp, Group
+from openmdao.api import ExplicitComponent, Group
 from openconcept.utilities import DVLabel
 
 
@@ -1393,37 +1393,37 @@ class HXGroup(Group):
     def setup(self):
         nn = self.options["num_nodes"]
 
-        iv = self.add_subsystem("dv", IndepVarComp(), promotes_outputs=["*"])
-        iv.add_output("case_thickness", val=2.0, units="mm")
-        iv.add_output("fin_thickness", val=0.102, units="mm")
-        iv.add_output("plate_thickness", val=0.2, units="mm")
-        iv.add_output("material_k", val=190, units="W/m/K")
-        iv.add_output("material_rho", val=2700, units="kg/m**3")
+        # Set the default values for promoted variables
+        self.set_input_defaults("case_thickness", val=2.0, units="mm")
+        self.set_input_defaults("fin_thickness", val=0.102, units="mm")
+        self.set_input_defaults("plate_thickness", val=0.2, units="mm")
+        self.set_input_defaults("material_k", val=190, units="W/m/K")
+        self.set_input_defaults("material_rho", val=2700, units="kg/m**3")
 
-        # iv.add_output('mdot_cold', val=np.ones(nn)*1.5, units='kg/s')
-        # iv.add_output('rho_cold', val=np.ones(nn)*0.5, units='kg/m**3')
-        # iv.add_output('mdot_hot', val=0.075*np.ones(nn), units='kg/s')
-        # iv.add_output('rho_hot', val=np.ones(nn)*1020.2, units='kg/m**3')
+        # self.set_input_defaults('mdot_cold', val=np.ones(nn)*1.5, units='kg/s')
+        # self.set_input_defaults('rho_cold', val=np.ones(nn)*0.5, units='kg/m**3')
+        # self.set_input_defaults('mdot_hot', val=0.075*np.ones(nn), units='kg/s')
+        # self.set_input_defaults('rho_hot', val=np.ones(nn)*1020.2, units='kg/m**3')
 
-        # iv.add_output('T_in_cold', val=np.ones(nn)*45, units='degC')
-        # iv.add_output('T_in_hot', val=np.ones(nn)*90, units='degC')
-        # iv.add_output('n_long_cold', val=3)
-        # iv.add_output('n_wide_cold', val=430)
-        # iv.add_output('n_tall', val=19)
+        # self.set_input_defaults('T_in_cold', val=np.ones(nn)*45, units='degC')
+        # self.set_input_defaults('T_in_hot', val=np.ones(nn)*90, units='degC')
+        # self.set_input_defaults('n_long_cold', val=3)
+        # self.set_input_defaults('n_wide_cold', val=430)
+        # self.set_input_defaults('n_tall', val=19)
 
-        iv.add_output("channel_height_cold", val=14, units="mm")
-        iv.add_output("channel_width_cold", val=1.35, units="mm")
-        iv.add_output("fin_length_cold", val=6, units="mm")
-        iv.add_output("cp_cold", val=1005, units="J/kg/K")
-        iv.add_output("k_cold", val=0.02596, units="W/m/K")
-        iv.add_output("mu_cold", val=1.789e-5, units="kg/m/s")
+        self.set_input_defaults("channel_height_cold", val=14, units="mm")
+        self.set_input_defaults("channel_width_cold", val=1.35, units="mm")
+        self.set_input_defaults("fin_length_cold", val=6, units="mm")
+        self.set_input_defaults("cp_cold", val=1005, units="J/kg/K")
+        self.set_input_defaults("k_cold", val=0.02596, units="W/m/K")
+        self.set_input_defaults("mu_cold", val=1.789e-5, units="kg/m/s")
 
-        iv.add_output("channel_height_hot", val=1, units="mm")
-        iv.add_output("channel_width_hot", val=1, units="mm")
-        iv.add_output("fin_length_hot", val=6, units="mm")
-        iv.add_output("cp_hot", val=3801, units="J/kg/K")
-        iv.add_output("k_hot", val=0.405, units="W/m/K")
-        iv.add_output("mu_hot", val=1.68e-3, units="kg/m/s")
+        self.set_input_defaults("channel_height_hot", val=1, units="mm")
+        self.set_input_defaults("channel_width_hot", val=1, units="mm")
+        self.set_input_defaults("fin_length_hot", val=6, units="mm")
+        self.set_input_defaults("cp_hot", val=3801, units="J/kg/K")
+        self.set_input_defaults("k_hot", val=0.405, units="W/m/K")
+        self.set_input_defaults("mu_hot", val=1.68e-3, units="kg/m/s")
 
         dvlist = [
             ["ac|propulsion|thermal|hx|n_wide_cold", "n_wide_cold", 430, None],

--- a/openconcept/thermal/tests/test_heat_exchanger.py
+++ b/openconcept/thermal/tests/test_heat_exchanger.py
@@ -15,6 +15,7 @@ from openconcept.thermal.heat_exchanger import (
     NTUEffectivenessActualHeatTransfer,
     OutletTemperatures,
     PressureDrop,
+    HXGroup,
 )
 
 
@@ -249,9 +250,9 @@ class OSFManualCheckTestGroup(Group):
 
         iv.add_output("T_in_cold", val=np.ones(nn) * 45, units="degC")
         iv.add_output("T_in_hot", val=np.ones(nn) * 90, units="degC")
-        iv.add_output("n_long_cold", val=25)
-        iv.add_output("n_wide_cold", val=25)
-        iv.add_output("n_tall", val=8)
+        iv.add_output("ac|propulsion|thermal|hx|n_long_cold", val=25)
+        iv.add_output("ac|propulsion|thermal|hx|n_wide_cold", val=25)
+        iv.add_output("ac|propulsion|thermal|hx|n_tall", val=8)
 
         iv.add_output("channel_height_cold", val=6.0, units="mm")
         iv.add_output("channel_width_cold", val=1.5, units="mm")
@@ -267,26 +268,7 @@ class OSFManualCheckTestGroup(Group):
         iv.add_output("k_hot", val=0.024, units="W/m/K")
         iv.add_output("mu_hot", val=1.7e-5, units="kg/m/s")
 
-        self.add_subsystem("osfgeometry", OffsetStripFinGeometry(), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem(
-            "redh", HydraulicDiameterReynoldsNumber(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"]
-        )
-        self.add_subsystem("osfdata", OffsetStripFinData(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem("nusselt", NusseltFromColburnJ(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem(
-            "convection", ConvectiveCoefficient(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"]
-        )
-        self.add_subsystem("finefficiency", FinEfficiency(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem("ua", UAOverall(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem("ntu", NTUMethod(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem(
-            "effectiveness", CrossFlowNTUEffectiveness(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"]
-        )
-        self.add_subsystem(
-            "heat", NTUEffectivenessActualHeatTransfer(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"]
-        )
-        self.add_subsystem("t_out", OutletTemperatures(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
-        self.add_subsystem("delta_p", PressureDrop(num_nodes=nn), promotes_inputs=["*"], promotes_outputs=["*"])
+        self.add_subsystem("hx", HXGroup(), promotes=["*"])
 
 
 class TestHXByHand(unittest.TestCase):
@@ -327,54 +309,54 @@ class TestHXByHand(unittest.TestCase):
 
         height_overall = n_cold_tall * (cold_one_layer_height + hot_one_layer_height)
         # note does not include case
-        assert_near_equal(prob["osfgeometry.height_overall"], height_overall / 1000, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.height_overall"], height_overall / 1000, tolerance=1e-6)
         width_overall = n_cold_wide * cold_one_cell_width
-        assert_near_equal(prob["osfgeometry.width_overall"], width_overall / 1000, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.width_overall"], width_overall / 1000, tolerance=1e-6)
         length_overall = n_cold_long * l_f_c
-        assert_near_equal(prob["osfgeometry.length_overall"], length_overall / 1000, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.length_overall"], length_overall / 1000, tolerance=1e-6)
         frontal_area = width_overall * height_overall
-        assert_near_equal(prob["osfgeometry.frontal_area"], frontal_area / 1000**2, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.frontal_area"], frontal_area / 1000**2, tolerance=1e-6)
 
         xs_area_cold = n_cold_wide * n_cold_tall * w_c * h_c
-        assert_near_equal(prob["osfgeometry.xs_area_cold"], xs_area_cold / 1000**2, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.xs_area_cold"], xs_area_cold / 1000**2, tolerance=1e-6)
         heat_transfer_area_cold = 2 * (w_c + h_c) * n_cold_tall * n_cold_wide * length_overall
         assert_near_equal(
-            prob["osfgeometry.heat_transfer_area_cold"], heat_transfer_area_cold / 1000**2, tolerance=1e-6
+            prob["hx.osfgeometry.heat_transfer_area_cold"], heat_transfer_area_cold / 1000**2, tolerance=1e-6
         )
         dh_cold = 4 * w_c * h_c * l_f_c / (2 * (w_c * l_f_c + h_c * l_f_c + t_f * h_c) + t_f * w_c)
-        assert_near_equal(prob["osfgeometry.dh_cold"], dh_cold / 1000, tolerance=1e-6)
-        assert_near_equal(prob["osfgeometry.dh_cold"], 2 * h_c * w_c / (h_c + w_c) / 1000, tolerance=3e-2)
+        assert_near_equal(prob["hx.osfgeometry.dh_cold"], dh_cold / 1000, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.dh_cold"], 2 * h_c * w_c / (h_c + w_c) / 1000, tolerance=3e-2)
 
         fin_area_ratio_cold = h_c / (h_c + w_c)
-        assert_near_equal(prob["osfgeometry.fin_area_ratio_cold"], fin_area_ratio_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.fin_area_ratio_cold"], fin_area_ratio_cold, tolerance=1e-6)
         contraction_ratio_cold = xs_area_cold / frontal_area
-        assert_near_equal(prob["osfgeometry.contraction_ratio_cold"], contraction_ratio_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.contraction_ratio_cold"], contraction_ratio_cold, tolerance=1e-6)
         alpha_cold = w_c / h_c
         delta_cold = t_f / l_f_c
         gamma_cold = t_f / w_c
-        assert_near_equal(prob["osfgeometry.alpha_cold"], alpha_cold, tolerance=1e-6)
-        assert_near_equal(prob["osfgeometry.delta_cold"], delta_cold, tolerance=1e-6)
-        assert_near_equal(prob["osfgeometry.gamma_cold"], gamma_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.alpha_cold"], alpha_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.delta_cold"], delta_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.gamma_cold"], gamma_cold, tolerance=1e-6)
 
         n_hot_wide = length_overall / hot_one_cell_width
         xs_area_hot = n_hot_wide * n_cold_tall * w_h * h_h
-        assert_near_equal(prob["osfgeometry.xs_area_hot"], xs_area_hot / 1000**2, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.xs_area_hot"], xs_area_hot / 1000**2, tolerance=1e-6)
         heat_transfer_area_hot = 2 * (w_h + h_h) * n_cold_tall * n_hot_wide * width_overall
         assert_near_equal(
-            prob["osfgeometry.heat_transfer_area_hot"], heat_transfer_area_hot / 1000**2, tolerance=1e-6
+            prob["hx.osfgeometry.heat_transfer_area_hot"], heat_transfer_area_hot / 1000**2, tolerance=1e-6
         )
         dh_hot = 2 * w_h * h_h / (w_h + h_h)
-        assert_near_equal(prob["osfgeometry.dh_hot"], dh_hot / 1000, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.dh_hot"], dh_hot / 1000, tolerance=1e-6)
         fin_area_ratio_hot = h_h / (h_h + w_h)
-        assert_near_equal(prob["osfgeometry.fin_area_ratio_hot"], fin_area_ratio_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.fin_area_ratio_hot"], fin_area_ratio_hot, tolerance=1e-6)
         contraction_ratio_hot = xs_area_hot / length_overall / height_overall
-        assert_near_equal(prob["osfgeometry.contraction_ratio_hot"], contraction_ratio_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.contraction_ratio_hot"], contraction_ratio_hot, tolerance=1e-6)
         alpha_hot = w_h / h_h
         delta_hot = t_f / l_f_h
         gamma_hot = t_f / w_h
-        assert_near_equal(prob["osfgeometry.alpha_hot"], alpha_hot, tolerance=1e-6)
-        assert_near_equal(prob["osfgeometry.delta_hot"], delta_hot, tolerance=1e-6)
-        assert_near_equal(prob["osfgeometry.gamma_hot"], gamma_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.alpha_hot"], alpha_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.delta_hot"], delta_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfgeometry.gamma_hot"], gamma_hot, tolerance=1e-6)
 
         mdot_cold = 0.1
         mdot_hot = 0.2
@@ -383,8 +365,8 @@ class TestHXByHand(unittest.TestCase):
 
         redh_cold = mdot_cold / (xs_area_cold / 1000**2) * dh_cold / 1000 / mu_cold
         redh_hot = mdot_hot / (xs_area_hot / 1000**2) * dh_hot / 1000 / mu_hot
-        assert_near_equal(prob["redh.Re_dh_cold"], redh_cold, tolerance=1e-6)
-        assert_near_equal(prob["redh.Re_dh_hot"], redh_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.redh.Re_dh_cold"], redh_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.redh.Re_dh_hot"], redh_hot, tolerance=1e-6)
 
         partials = prob.check_partials(method="cs", compact_print=True, show_only_incorrect=True, step=1e-50)
         assert_check_partials(partials)
@@ -406,8 +388,8 @@ class TestHXByHand(unittest.TestCase):
             * gamma_hot**-0.0678
             * (1 + 5.269e-5 * redh_hot**1.340 * alpha_hot**0.504 * delta_hot**0.456 * gamma_hot**-1.055) ** 0.1
         )
-        assert_near_equal(prob["osfdata.j_hot"], j_hot, tolerance=1e-6)
-        assert_near_equal(prob["osfdata.j_cold"], j_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfdata.j_hot"], j_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfdata.j_cold"], j_cold, tolerance=1e-6)
         f_cold = (
             9.6243
             * redh_cold**-0.7422
@@ -425,8 +407,8 @@ class TestHXByHand(unittest.TestCase):
             * gamma_hot**-0.2659
             * (1 + 7.669e-8 * redh_hot**4.429 * alpha_hot**0.920 * delta_hot**3.767 * gamma_hot**0.236) ** 0.1
         )
-        assert_near_equal(prob["osfdata.f_hot"], f_hot, tolerance=1e-6)
-        assert_near_equal(prob["osfdata.f_cold"], f_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfdata.f_hot"], f_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.osfdata.f_cold"], f_cold, tolerance=1e-6)
 
         cp_cold = 1005
         k_cold = 0.02596
@@ -436,8 +418,8 @@ class TestHXByHand(unittest.TestCase):
         h_cold = j_cold * cp_cold ** (1 / 3) * (k_cold / mu_cold) ** (2 / 3) * mdot_cold / xs_area_cold * 1000**2
         h_hot = j_hot * cp_hot ** (1 / 3) * (k_hot / mu_hot) ** (2 / 3) * mdot_hot / xs_area_hot * 1000**2
 
-        assert_near_equal(prob["convection.h_conv_cold"], h_cold, tolerance=1e-6)
-        assert_near_equal(prob["convection.h_conv_hot"], h_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.convection.h_conv_cold"], h_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.convection.h_conv_hot"], h_hot, tolerance=1e-6)
 
         k_alu = 190
         # TODO kays and london has a different expression for fin efficiency. why
@@ -445,11 +427,11 @@ class TestHXByHand(unittest.TestCase):
         m = np.sqrt(2 * h_cold / k_alu / (t_f / 1000))
         eta_f_cold = np.tanh(m * h_c / 2 / 1000) / m / (h_c / 2 / 1000)
         eta_o_cold = 1 - (1 - eta_f_cold) * fin_area_ratio_cold
-        assert_near_equal(prob["finefficiency.eta_overall_cold"], eta_o_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.finefficiency.eta_overall_cold"], eta_o_cold, tolerance=1e-6)
         m = np.sqrt(2 * h_hot / k_alu / (t_f / 1000))
         eta_f_hot = np.tanh(m * h_h / 2 / 1000) / m / (h_h / 2 / 1000)
         eta_o_hot = 1 - (1 - eta_f_hot) * fin_area_ratio_hot
-        assert_near_equal(prob["finefficiency.eta_overall_hot"], eta_o_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.finefficiency.eta_overall_hot"], eta_o_hot, tolerance=1e-6)
 
         rc = 1 / eta_o_cold / (heat_transfer_area_cold / 1000**2) / h_cold
         rh = 1 / eta_o_hot / (heat_transfer_area_hot / 1000**2) / h_hot
@@ -457,7 +439,7 @@ class TestHXByHand(unittest.TestCase):
         # TODO wall resistance not currently accounted for, less than 1% effect
         rw = 0.0
         uaoverall = 1 / (rc + rh + rw)
-        assert_near_equal(prob["ua.UA_overall"], uaoverall, tolerance=1e-6)
+        assert_near_equal(prob["hx.ua.UA_overall"], uaoverall, tolerance=1e-6)
 
         cmin = np.minimum(mdot_cold * cp_cold, mdot_hot * cp_hot)
         cmax = np.maximum(mdot_cold * cp_cold, mdot_hot * cp_hot)
@@ -465,16 +447,16 @@ class TestHXByHand(unittest.TestCase):
         cratio = cmin / cmax
         ntu = uaoverall / cmin
         effectiveness = 1 - np.exp(ntu**0.22 * (np.exp(-cratio * ntu**0.78) - 1) / cratio)
-        assert_near_equal(prob["ntu.NTU"], ntu, tolerance=1e-6)
-        assert_near_equal(prob["effectiveness.effectiveness"], effectiveness, tolerance=1e-6)
+        assert_near_equal(prob["hx.ntu.NTU"], ntu, tolerance=1e-6)
+        assert_near_equal(prob["hx.effectiveness.effectiveness"], effectiveness, tolerance=1e-6)
 
         heat_transfer = cmin * effectiveness * (90 - 45)
-        assert_near_equal(prob["heat.heat_transfer"], heat_transfer, tolerance=1e-6)
+        assert_near_equal(prob["hx.heat.heat_transfer"], heat_transfer, tolerance=1e-6)
 
         tout_cold = 45 + heat_transfer / mdot_cold / cp_cold + 273.15
         tout_hot = 90 - heat_transfer / mdot_hot / cp_hot + 273.15
-        assert_near_equal(prob["t_out.T_out_cold"], tout_cold, tolerance=1e-6)
-        assert_near_equal(prob["t_out.T_out_hot"], tout_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.t_out.T_out_cold"], tout_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.t_out.T_out_hot"], tout_hot, tolerance=1e-6)
 
         Gcold = mdot_cold / (xs_area_cold / 1000**2)
         Ghot = mdot_hot / (xs_area_hot / 1000**2)
@@ -485,8 +467,8 @@ class TestHXByHand(unittest.TestCase):
         Ke = -0.1
         pressure_drop_cold = -(Gcold**2) / 2 / rho_cold * ((Kc + Ke) + f_cold * 4 * length_overall / dh_cold)
         pressure_drop_hot = -(Ghot**2) / 2 / rho_hot * ((Kc + Ke) + f_hot * 4 * width_overall / dh_hot)
-        assert_near_equal(prob["delta_p.delta_p_cold"], pressure_drop_cold, tolerance=1e-6)
-        assert_near_equal(prob["delta_p.delta_p_hot"], pressure_drop_hot, tolerance=1e-6)
+        assert_near_equal(prob["hx.delta_p.delta_p_cold"], pressure_drop_cold, tolerance=1e-6)
+        assert_near_equal(prob["hx.delta_p.delta_p_hot"], pressure_drop_hot, tolerance=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
The heat exchanger model previously had an independent variable component connected to most inputs, such as channel geometry, number of channels in each dimension, etc. This prevented users from connecting outputs from other components to these inputs in the heat exchanger model. This fix removes the independent variable component and instead uses OpenMDAO's `set_input_defaults`. This means OpenMDAO will automatically connect an `IndepVarComp` with these values if nothing is connected by the user.

This change also allows the removal of the copy of all `HXGroup`'s internals into the heat exchanger test script.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Refactoring (no functional changes, no API changes)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
