### PR TITLE
Fix the failing GitHub Actions

### DIFF
--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -56,8 +56,8 @@ jobs:
       run: |
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
-        conda install numpy=${{ matrix.NUMPY_VERSION_OLDEST }} scipy=${{ matrix.SCIPY_VERSION_OLDEST }}
-        pip install om-pycycle
+        conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }}
+        pip install scipy=${{ matrix.SCIPY_VERSION_OLDEST }} om-pycycle
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}
       run: |

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -95,11 +95,12 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-  
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   # --- publish to PyPI
   pypi:
     needs: [build]

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -56,7 +56,8 @@ jobs:
       run: |
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
-        pip install numpy==${{ matrix.NUMPY_VERSION_OLDEST }} scipy==${{ matrix.SCIPY_VERSION_OLDEST }} om-pycycle
+        conda install numpy=${{ matrix.NUMPY_VERSION_OLDEST }} scipy=${{ matrix.SCIPY_VERSION_OLDEST }}
+        pip install om-pycycle
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}
       run: |

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -28,7 +28,7 @@ jobs:
         PIP_VERSION_OLDEST: ['23.0.1']  # pip>=23.1 cannot build the oldest OpenMDAO
         SETUPTOOLS_VERSION_OLDEST: ['66.0.0']  # setuptools >= 67.0.0 can't build the oldest OpenMDAO
         NUMPY_VERSION_OLDEST: ['1.20']  # latest is most recent on PyPI
-        SCIPY_VERSION_OLDEST: ['1.6.0']  # latest is most recent on PyPI
+        SCIPY_VERSION_OLDEST: ['1.7.0']  # latest is most recent on PyPI
         OPENMDAO_VERSION_OLDEST: ['3.21']  # latest is most recent on PyPI
       fail-fast: false
     env:
@@ -51,13 +51,11 @@ jobs:
         auto-update-conda: true
         python-version: ${{ matrix.PYTHON_VERSION_LATEST }}
 
-    # include the nomkl when installing from conda since it seems that MKL does not work on the ARM Mac environments
     - name: Install dependencies (oldest versions)
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
-        conda install nomkl
         conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }} scipy=${{ matrix.SCIPY_VERSION_OLDEST }}
         pip install om-pycycle
     - name: Install dependencies (latest versions)

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -51,11 +51,13 @@ jobs:
         auto-update-conda: true
         python-version: ${{ matrix.PYTHON_VERSION_LATEST }}
 
+    # include the nomkl when installing from conda since it seems that MKL does not work on the ARM Mac environments
     - name: Install dependencies (oldest versions)
       if: ${{ matrix.dep-versions == 'oldest' }}
       run: |
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
+        conda install nomkl
         conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }} scipy=${{ matrix.SCIPY_VERSION_OLDEST }}
         pip install om-pycycle
     - name: Install dependencies (latest versions)

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -56,8 +56,8 @@ jobs:
       run: |
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
-        conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }}
-        pip install scipy==${{ matrix.SCIPY_VERSION_OLDEST }} om-pycycle
+        conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }} scipy=${{ matrix.SCIPY_VERSION_OLDEST }}
+        pip install om-pycycle
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}
       run: |

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -57,7 +57,7 @@ jobs:
         conda config --set always_yes yes
         python -m pip install pip==${{ matrix.PIP_VERSION_OLDEST }} setuptools==${{ matrix.SETUPTOOLS_VERSION_OLDEST }} --upgrade wheel
         conda install -c conda-forge numpy=${{ matrix.NUMPY_VERSION_OLDEST }}
-        pip install scipy=${{ matrix.SCIPY_VERSION_OLDEST }} om-pycycle
+        pip install scipy==${{ matrix.SCIPY_VERSION_OLDEST }} om-pycycle
     - name: Install dependencies (latest versions)
       if: ${{ matrix.dep-versions == 'latest' }}
       run: |

--- a/.github/workflows/openconcept.yaml
+++ b/.github/workflows/openconcept.yaml
@@ -40,13 +40,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup Python ${{ matrix.PYTHON_VERSION_OLDEST }}
       if: ${{ matrix.dep-versions == 'oldest' }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: ${{ matrix.PYTHON_VERSION_OLDEST }}
     - name: Setup Python ${{ matrix.PYTHON_VERSION_LATEST }}
       if: ${{ matrix.dep-versions == 'latest' }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: ${{ matrix.PYTHON_VERSION_LATEST }}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,7 +70,7 @@ OpenConcept is tested regularly on builds with the oldest and latest supported p
      - 1.20
      - latest
    * - SciPy
-     - 1.6.0
+     - 1.7.0
      - latest
    * - OpenAeroStruct
      - latest

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ OpenConcept is tested regularly on builds with the oldest and latest supported p
 | Python | 3.8 | 3.11 |
 | OpenMDAO | 3.21 | 3.30 |
 | NumPy | 1.20 | latest |
-| SciPy | 1.6.0 | latest |
+| SciPy | 1.7.0 | latest |
 | OpenAeroStruct | latest | latest |
 
 ## Citation

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         # Update the oldest package versions in the GitHub Actions build file, the readme,
         # and the index.rst file in the docs when you change these
         "numpy>=1.20",
-        "scipy>=1.6.0",
+        "scipy>=1.7.0",
         "openmdao >=3.21, <=3.30",
     ],
     extras_require={


### PR DESCRIPTION
## Purpose
Fix the GitHub Actions failures on the MacOS builds when setting up Python.

SciPy 1.6.0 wasn't working on the ARM Mac builds, so I've bumped the minimum SciPy version from 1.6.0 to 1.7.0, which now works correctly.

Finally, this has some minor codecov changes that seem to work better now (the main changes were a new token in the OpenConcept secrets and bumping the codecov action to version 4).

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Bugfix (non-breaking change which fixes an issue)
