### PR TITLE
Fixed a typo and takeoff plotting

### DIFF
--- a/doc/features/mission.rst
+++ b/doc/features/mission.rst
@@ -42,7 +42,7 @@ The additional takeoff phases are:
 - ``v0v1``: from a standstill to decision speed (v1). An instance of ``GroundRollPhase``.
 - ``v1vr``: from v1 to rotation. An instance of ``GroundRollPhase``.
 - ``rotate``: rotation in the air before steady climb. An instance of ``RotationPhase`` or ``RobustRotationPhase``.
-- ``v1vr``: energency stopping from v1 to a stop. An instance of ``GroundRollPhase``.
+- ``v1v0``: energency stopping from v1 to a stop. An instance of ``GroundRollPhase``.
 
 We use ``BLIImplicitSolve`` to solve for the decision speed ``v1`` where the one-engine-out takeoff distance is equal to the braking distance for rejected takeoff.
 

--- a/openconcept/examples/HybridTwin.py
+++ b/openconcept/examples/HybridTwin.py
@@ -322,7 +322,6 @@ def show_outputs(prob):
             phases,
             x_label=x_label,
             y_labels=y_labels,
-            marker="-",
             plot_title="Takeoff Profile",
         )
 


### PR DESCRIPTION
## Purpose
Fixed a minor typo in the docs for the takeoff analysis. Also changed the marker style to default `"o"` to avoid plotting the nominal takeoff and the emergency stop in one continuous line.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- Documentation update

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
