### PR TITLE
Add missing packages to source docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -405,12 +405,17 @@ if generate_srcdocs:
         "aerodynamics",
         "aerodynamics.openaerostruct",
         "atmospherics",
+        "costs",
         "energy_storage",
+        "energy_storage.hydrogen",
+        "geometry",
         "mission",
         "propulsion",
         "propulsion.systems",
+        "stability",
         "thermal",
         "utilities",
         "utilities.math",
+        "weights",
     ]
     generate_src_docs(".", "../openconcept", packages)


### PR DESCRIPTION
## Purpose
A few packages weren't showing up in the source docs because they hadn't been added to `conf.py`, this makes those visible. Now everything shows up except examples and propulsion data because those don't need API documentation.

## Type of change
- Documentation update

## Testing
All modules should show up in sphinx PR build

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
