### PR TITLE
Fix numpy max version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=[
         # Update the oldest package versions in the GitHub Actions build file, the readme,
         # and the index.rst file in the docs when you change these
-        "numpy >=1.20, <=1.26",
+        "numpy >=1.20, <2",
         "scipy>=1.7.0",
         "openmdao >=3.21, <=3.38",
     ],


### PR DESCRIPTION
## Purpose
Currently OpenCOncept specifies `numpy<=1.26` in its depencies which I presume is to avoid numpy 2. However, this will forcibly downgrade anyone using numpy 1.26.1, 1.26.2 etc to 1.26.0, which is not desirable.
